### PR TITLE
generate_opp_message can now take multiple files

### DIFF
--- a/GenerateOppMessage.cmake
+++ b/GenerateOppMessage.cmake
@@ -3,34 +3,36 @@ cmake_minimum_required(VERSION 3.1)
 include(CMakeParseArguments)
 
 # generate sources for messages via opp_msgc
-macro(generate_opp_message _msg_input)
-    cmake_parse_arguments(_gen_opp_msg "" "TARGET" "" ${ARGN})
+macro(generate_opp_message _msg_target)
+    cmake_parse_arguments(_gen_opp_msg "" "" "MESSAGE_FILES" ${ARGN})
     if(_gen_opp_msg_UNPARSED_ARGUMENTS)
         message(SEND_ERROR "generate_opp_message called with invalid arguments: ${_gen_opp_msg_UNPARSED_ARGUMENTS}")
     endif()
 
-    get_filename_component(_msg_name "${_msg_input}" NAME_WE)
-    get_filename_component(_msg_dir "${_msg_input}" DIRECTORY)
-    # From OMNet+ 6 opp_msgc is replaced by opp_msgtool
-    # The tool uses the same syntax, but only outputs files in their source directory
-    set(_msg_output_root ${PROJECT_SOURCE_DIR})
-    # Gather the relative path from the source directory to the message input
-    file(RELATIVE_PATH _msg_prefix ${_msg_output_root} ${CMAKE_CURRENT_SOURCE_DIR}/${_msg_dir})
+    foreach(_msg_input IN ${_gen_opp_msg_MESSAGES_FILES})
+        get_filename_component(_msg_name "${_msg_input}" NAME_WE)
+        get_filename_component(_msg_dir "${_msg_input}" DIRECTORY)
+        # From OMNet+ 6 opp_msgc is replaced by opp_msgtool
+        # The tool uses the same syntax, but only outputs files in their source directory
+        set(_msg_output_root ${PROJECT_SOURCE_DIR})
+        # Gather the relative path from the source directory to the message input
+        file(RELATIVE_PATH _msg_prefix ${_msg_output_root} ${CMAKE_CURRENT_SOURCE_DIR}/${_msg_dir})
 
-    set(_msg_output_directory "${_msg_output_root}/${_msg_prefix}")
-    set(_msg_output_source "${_msg_output_directory}/${_msg_name}_m.cc")
-    set(_msg_output_header "${_msg_output_directory}/${_msg_name}_m.h")
+        set(_msg_output_directory "${_msg_output_root}/${_msg_prefix}")
+        set(_msg_output_source "${_msg_output_directory}/${_msg_name}_m.cc")
+        set(_msg_output_header "${_msg_output_directory}/${_msg_name}_m.h")
 
-    add_custom_command(OUTPUT "${_msg_output_source}" "${_msg_output_header}"
-        COMMAND ${OMNETPP_MSGC}
+        add_custom_command(OUTPUT "${_msg_output_source}" "${_msg_output_header}"
+            COMMAND ${OMNETPP_MSGC}
             ARGS -s _m.cc ${CMAKE_CURRENT_SOURCE_DIR}/${_msg_input}
-        DEPENDS ${_msg_input} ${OMNETPP_MSGC}
-        COMMENT "Generating ${_msg_prefix}/${_msg_name}"
-        VERBATIM)
+            DEPENDS ${_msg_input} ${OMNETPP_MSGC}
+            COMMENT "Generating ${_msg_prefix}/${_msg_name}"
+            VERBATIM)
 
-    target_sources(${_gen_opp_msg_TARGET} PRIVATE "${_msg_output_source}" "${_msg_output_header}")
-    target_include_directories(${_gen_opp_msg_TARGET} PUBLIC ${_msg_dir})
-    message("")
+        target_sources(${_msg_target} PRIVATE "${_msg_output_source}" "${_msg_output_header}")
+        target_include_directories(${_msg_target} PUBLIC ${_msg_dir})
+        message("")
+    endforeach()
 endmacro()
 
 macro(clean_opp_messages)

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ The following is *one* of many other ways to do it.
         messages/a.msg
         messages/b.msg)
 
-    generate_opp_message(${MESSAGE_SOURCES}
-        TARGET project_library)
+    generate_opp_message(project_library
+        MESSAGE_FILES ${MESSAGE_SOURCES})
 
     # You will need to tweak and add the additional properties for your project
     set_target_properties(project_library PROPERTIES
@@ -86,7 +86,7 @@ The following is *one* of many other ways to do it.
 
 ### Macros Available
 
-- `generate_opp_message`(`<file1>` ... *`TARGET`* `<target1> ...`)  
+- `generate_opp_message`(`<target>` *`MESSAGE_FILES`* `<file1> ...`)  
   Generates and links a message file to a given target.
 
 - `import_opp_target`(`<opp_makemake_target>` `<Makefile>` [ `<cmake_target_file>` ])  


### PR DESCRIPTION
The order of the arguments are also changed. The message files that are
to be added are denoted with `MESSAGE_FILES`