### PR TITLE
generate_opp_message: Fixed wrong iteration type in foreach

### DIFF
--- a/GenerateOppMessage.cmake
+++ b/GenerateOppMessage.cmake
@@ -3,35 +3,35 @@ cmake_minimum_required(VERSION 3.1)
 include(CMakeParseArguments)
 
 # generate sources for messages via opp_msgc
-macro(generate_opp_message _msg_target)
-    cmake_parse_arguments(_gen_opp_msg "" "" "MESSAGE_FILES" ${ARGN})
-    if(_gen_opp_msg_UNPARSED_ARGUMENTS)
-        message(SEND_ERROR "generate_opp_message called with invalid arguments: ${_gen_opp_msg_UNPARSED_ARGUMENTS}")
+macro(generate_opp_message)
+    cmake_parse_arguments(GEN_OPP_MSG "LEGACY" "" "MESSAGE_FILES" ${ARGN})
+    if(NOT DEFINED GEN_OPP_MSG_MESSAGE_FILES)
+        message(SEND_ERROR "generate_opp_message called without MESSAGE_FILES! "
+                           "Valid options are: <MESSAGE_FILES items> [LEGACY]")
     endif()
 
-    foreach(_msg_input IN ${_gen_opp_msg_MESSAGES_FILES})
+    if(GEN_OPP_MSG_LEGACY)
+        set(_msg_version_arg "--msg4")
+    endif()
+
+    foreach(_msg_input IN ITEMS ${GEN_OPP_MSG_MESSAGE_FILES})
+        if(NOT IS_ABSOLUTE ${_msg_input})
+            set(_msg_output_source "${CMAKE_CURRENT_SRC_DIR}/${_msg_input}")
+        endif()
+
         get_filename_component(_msg_name "${_msg_input}" NAME_WE)
         get_filename_component(_msg_dir "${_msg_input}" DIRECTORY)
-        # From OMNet+ 6 opp_msgc is replaced by opp_msgtool
-        # The tool uses the same syntax, but only outputs files in their source directory
-        set(_msg_output_root ${PROJECT_SOURCE_DIR})
-        # Gather the relative path from the source directory to the message input
-        file(RELATIVE_PATH _msg_prefix ${_msg_output_root} ${CMAKE_CURRENT_SOURCE_DIR}/${_msg_dir})
 
-        set(_msg_output_directory "${_msg_output_root}/${_msg_prefix}")
-        set(_msg_output_source "${_msg_output_directory}/${_msg_name}_m.cc")
-        set(_msg_output_header "${_msg_output_directory}/${_msg_name}_m.h")
+        # Path of sources and headers to be generated, respectively
+        set(_msg_output_source "${_msg_dir}/${_msg_name}_m.cc")
+        set(_msg_output_header "${_msg_dir}/${_msg_name}_m.h")
 
         add_custom_command(OUTPUT "${_msg_output_source}" "${_msg_output_header}"
             COMMAND ${OMNETPP_MSGC}
-            ARGS -s _m.cc ${CMAKE_CURRENT_SOURCE_DIR}/${_msg_input}
+            ARGS ${_msg_version_arg} -s _m.cc ${_msg_input}
             DEPENDS ${_msg_input} ${OMNETPP_MSGC}
-            COMMENT "Generating ${_msg_prefix}/${_msg_name}"
+            COMMENT "Generating ${_msg_dir}/${_msg_name}_m.(cc|h)"
             VERBATIM)
-
-        target_sources(${_msg_target} PRIVATE "${_msg_output_source}" "${_msg_output_header}")
-        target_include_directories(${_msg_target} PUBLIC ${_msg_dir})
-        message("")
     endforeach()
 endmacro()
 


### PR DESCRIPTION
Also does not alter target's include directories anymore, as this would
allow the generated header files to be included from CWD.

Note that with these changes, `file` is preferred over `set` when
defining files, since absolute paths are preferred.