### PR TITLE
Fix generate_opp_message not actually iterating over files

### DIFF
--- a/GenerateOppMessage.cmake
+++ b/GenerateOppMessage.cmake
@@ -4,9 +4,13 @@ include(CMakeParseArguments)
 
 # generate sources for messages via opp_msgc
 macro(generate_opp_message _msg_target)
-    cmake_parse_arguments(_gen_opp_msg "" "" "MESSAGE_FILES" ${ARGN})
-    if(_gen_opp_msg_UNPARSED_ARGUMENTS)
-        message(SEND_ERROR "generate_opp_message called with invalid arguments: ${_gen_opp_msg_UNPARSED_ARGUMENTS}")
+    cmake_parse_arguments(_gen_opp_msg "LEGACY" "" "MESSAGE_FILES" ${ARGN})
+    if(NOT DEFINED _gen_opp_msg_MESSAGE_FILES)
+        message(SEND_ERROR "generate_opp_message called without MESSAGE_FILES!")
+    endif()
+
+    if(_gen_opp_msg_LEGACY)
+        set(_msg_version_arg "--msg4")
     endif()
 
     foreach(_msg_input IN ${_gen_opp_msg_MESSAGES_FILES})
@@ -24,7 +28,7 @@ macro(generate_opp_message _msg_target)
 
         add_custom_command(OUTPUT "${_msg_output_source}" "${_msg_output_header}"
             COMMAND ${OMNETPP_MSGC}
-            ARGS -s _m.cc ${CMAKE_CURRENT_SOURCE_DIR}/${_msg_input}
+            ARGS ${_msg_version_arg} -s _m.cc ${CMAKE_CURRENT_SOURCE_DIR}/${_msg_input}
             DEPENDS ${_msg_input} ${OMNETPP_MSGC}
             COMMENT "Generating ${_msg_prefix}/${_msg_name}"
             VERBATIM)

--- a/GenerateOppMessage.cmake
+++ b/GenerateOppMessage.cmake
@@ -13,7 +13,7 @@ macro(generate_opp_message _msg_target)
         set(_msg_version_arg "--msg4")
     endif()
 
-    foreach(_msg_input IN ${_gen_opp_msg_MESSAGES_FILES})
+    foreach(_msg_input IN ITEMS ${_gen_opp_msg_MESSAGE_FILES})
         get_filename_component(_msg_name "${_msg_input}" NAME_WE)
         get_filename_component(_msg_dir "${_msg_input}" DIRECTORY)
         # From OMNet+ 6 opp_msgc is replaced by opp_msgtool

--- a/GenerateOppMessage.cmake
+++ b/GenerateOppMessage.cmake
@@ -29,12 +29,10 @@ macro(generate_opp_message _msg_target)
             COMMAND ${OMNETPP_MSGC}
             ARGS ${_msg_version_arg} -s _m.cc ${_msg_input}
             DEPENDS ${_msg_input} ${OMNETPP_MSGC}
-            COMMENT "Generating ${_msg_prefix}/${_msg_name}"
+            COMMENT "Generating ${_msg_dir}/${_msg_name}_m.(cc|h)"
             VERBATIM)
 
-        target_sources(${_msg_target} PRIVATE "${_msg_output_source}" "${_msg_output_header}")
-        target_include_directories(${_msg_target} PUBLIC ${_msg_dir})
-        message("")
+        target_sources(${_msg_target} PRIVATE "${_msg_output_source}")
     endforeach()
 endmacro()
 

--- a/GenerateOppMessage.cmake
+++ b/GenerateOppMessage.cmake
@@ -14,21 +14,20 @@ macro(generate_opp_message _msg_target)
     endif()
 
     foreach(_msg_input IN ITEMS ${_gen_opp_msg_MESSAGE_FILES})
+        if(NOT IS_ABSOLUTE ${_msg_input})
+            set(_msg_input "${CMAKE_CURRENT_SOURCE_DIR}/${_msg_input}")
+        endif()
+
         get_filename_component(_msg_name "${_msg_input}" NAME_WE)
         get_filename_component(_msg_dir "${_msg_input}" DIRECTORY)
-        # From OMNet+ 6 opp_msgc is replaced by opp_msgtool
-        # The tool uses the same syntax, but only outputs files in their source directory
-        set(_msg_output_root ${PROJECT_SOURCE_DIR})
-        # Gather the relative path from the source directory to the message input
-        file(RELATIVE_PATH _msg_prefix ${_msg_output_root} ${CMAKE_CURRENT_SOURCE_DIR}/${_msg_dir})
 
-        set(_msg_output_directory "${_msg_output_root}/${_msg_prefix}")
-        set(_msg_output_source "${_msg_output_directory}/${_msg_name}_m.cc")
-        set(_msg_output_header "${_msg_output_directory}/${_msg_name}_m.h")
+        # Path of sources and headers to be generated, respectively
+        set(_msg_output_source "${_msg_dir}/${_msg_name}_m.cc")
+        set(_msg_output_header "${_msg_dir}/${_msg_name}_m.h")
 
         add_custom_command(OUTPUT "${_msg_output_source}" "${_msg_output_header}"
             COMMAND ${OMNETPP_MSGC}
-            ARGS ${_msg_version_arg} -s _m.cc ${CMAKE_CURRENT_SOURCE_DIR}/${_msg_input}
+            ARGS ${_msg_version_arg} -s _m.cc ${_msg_input}
             DEPENDS ${_msg_input} ${OMNETPP_MSGC}
             COMMENT "Generating ${_msg_prefix}/${_msg_name}"
             VERBATIM)


### PR DESCRIPTION
Fixes some issues that did not allow for absolute paths as well.

Also adds feature for legacy option, enabled like this:

```{cmake}
generate_opp_message(iamatarget MESSAGE_FILES some.msg;files.msg LEGACY)
```